### PR TITLE
chore(ci): add lint + pytest workflow on Python 3.10/3.11/3.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            setup.py
+
+      - name: Install system dependencies (FFmpeg)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Install package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint (errors only — undefined names, syntax errors)
+        run: |
+          flake8 src/ tests/ \
+            --count \
+            --select=E9,F63,F7,F82 \
+            --show-source \
+            --statistics
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,3 +53,17 @@ jobs:
       - name: Run tests
         run: |
           pytest tests/ -v --tb=short
+
+  ci-passed:
+    name: CI passed
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Aggregate matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more matrix jobs failed (result=${{ needs.test.result }})"
+            exit 1
+          fi
+          echo "All matrix jobs succeeded."


### PR DESCRIPTION
## Summary
- Add \`.github/workflows/CI.yml\` triggered on PR + push against \`dev\` and \`main\`.
- Matrix runs against Python 3.10, 3.11, and 3.12 on \`ubuntu-latest\` with pip cache + concurrency cancellation.
- Lints with flake8 errors-only (E9/F63/F7/F82) and runs the existing \`pytest tests/\` suite.

## Test plan
- [ ] CI run on this PR is green across all three Python versions.
- [ ] README badge (\`workflows/CI/badge.svg\`) starts resolving once this workflow has run at least once on the branch GitHub picks for the badge (after merge to \`main\`).
- [ ] Once green, add \`required_status_checks\` for the \`Python 3.10 / 3.11 / 3.12\` checks to the \`For main\` ruleset (separate change, file delivered alongside this work).

Closes #27