### PR TITLE
chore: extend .gitignore (OS noise + model weights)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,35 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project outputs (generated lessons, checkpoints scratch)
+outputs/
+
+# OS files
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*~
+
+# Editor noise
+.idea/
+.vscode/
+*.swp
+*.swo
+*.tmp
+*.bak
+
+# Model weights / checkpoints — never commit
+*.safetensors
+*.ckpt
+*.pt
+*.bin
+*.gguf
+*.onnx


### PR DESCRIPTION
## Summary
- Add cross-platform OS / editor ignore block (`.DS_Store`, `Thumbs.db`, `.idea/`, `.vscode/`, swap files).
- Keep the local `outputs/` addition.
- Add model-weight extensions (`.safetensors`, `.ckpt`, `.pt`, `.bin`, `.gguf`, `.onnx`) so checkpoint binaries are ignored everywhere by default.

## Test plan
- [ ] CI green.
- [ ] After merge, `git status` no longer surfaces `.DS_Store` in this repo locally.
- [ ] A test `touch outputs/lesson.safetensors` then `git status` confirms it's ignored.

Closes #29